### PR TITLE
chore(ci): update flake.lock workflow to create PR instead of pushing directly

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 
@@ -19,14 +20,16 @@ jobs:
         working-directory: .config/nix/modules/home
         run: nix flake update
 
-      - name: Commit and push if changed
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .config/nix/modules/home/flake.lock
-          if git diff --staged --quiet; then
-            echo "flake.lock is already up to date"
-          else
-            git commit -m "chore(nix): update flake.lock"
-            git push
-          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(nix): update flake.lock"
+          branch: automation/update-flake-lock
+          delete-branch: true
+          title: "chore(nix): update flake.lock"
+          body: |
+            Automated update of `flake.lock` via the `nix flake update` command.
+
+            This PR was created automatically by the [Update flake.lock](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow.
+          add-paths: .config/nix/modules/home/flake.lock


### PR DESCRIPTION
Replace the direct commit-and-push step with peter-evans/create-pull-request
so that flake.lock updates go through a PR review process rather than being
committed straight to the default branch.

https://claude.ai/code/session_01XVjNB3LKDn1gEwnEVuWyDp