### PR TITLE
Install Claude Desktop app without bin/claude wrapper

### DIFF
--- a/.config/nix/modules/home/home.nix
+++ b/.config/nix/modules/home/home.nix
@@ -29,6 +29,13 @@
     llm-agents.codex
     llm-agents.gemini-cli
     llm-agents.claude-code
+    # Claude Desktop app only (no bin/claude wrapper to avoid conflict with claude-code CLI)
+    (pkgs.brewCasks.claude.overrideAttrs (old: {
+      installPhase = ''
+        mkdir -p "$out/Applications/Claude.app"
+        cp -R . "$out/Applications/Claude.app"
+      '';
+    }))
     raycast
     comma
     # VCS


### PR DESCRIPTION
## Summary
- Add `brewCasks.claude` back with overridden `installPhase` that only installs the `.app` bundle
- Removes the `bin/claude` wrapper from Claude Desktop so `claude-code`'s CLI binary takes priority in PATH
- `claude` command → Claude Code CLI, Claude Desktop → accessible as macOS app via Spotlight/Raycast

## Test plan
- [ ] Run `home-manager switch` and verify it builds
- [ ] Confirm `claude` in terminal opens Claude Code CLI
- [ ] Confirm Claude Desktop app is available in `~/Applications`

🤖 Generated with [Claude Code](https://claude.com/claude-code)